### PR TITLE
Simple health check endpoint

### DIFF
--- a/cmd/webapi/main.go
+++ b/cmd/webapi/main.go
@@ -28,11 +28,20 @@ func main() {
 	rdb = redisutil.InitializeClient()
 
 	// Setup HTTP server
+	http.Handle("/health", logging.LoggingMiddleware(http.HandlerFunc(handleHealth)))
 	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/scan", logging.LoggingMiddleware(http.HandlerFunc(handleScan)))
 	http.Handle("/report", logging.LoggingMiddleware(http.HandlerFunc(handleReport)))
 	log.Println("Server started on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	// Set the content type and write the response
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	response := map[string]string{"result": "ok"}
+	json.NewEncoder(w).Encode(response)
 }
 
 func handleReport(w http.ResponseWriter, r *http.Request) {

--- a/cmd/webapi/main_test.go
+++ b/cmd/webapi/main_test.go
@@ -34,3 +34,24 @@ func TestHandleScan(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 }
+
+func TestHandleHealth(t *testing.T) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(handleHealth)
+	handler.ServeHTTP(rr, req)
+
+	response := rr.Result()
+	headers := rr.Header()
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", response.StatusCode, http.StatusOK)
+	}
+
+	if content_type := headers.Get("content-type"); content_type != "application/json" {
+		t.Errorf("handler returned wrong content-type: got '%v' want '%v'", content_type, "application/json")
+	}
+}


### PR DESCRIPTION
Simple healthcheck endpoint for orchestration liveliness probe.

See `Pod#spec.containers[*].livenessProbe` documentation [0]

[0]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/