### PR TITLE
Add --slow option to scanworker if the environment variable SLOW_RUN=1

### DIFF
--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -138,5 +138,15 @@ func calculateResultName(imageName string) string {
 }
 
 func generateTrivyCmdArgs(resultFileName, targetDir string) []string {
-	return []string{"image", "--format", "json", "--output", resultFileName, "--input", targetDir}
+	cmdArgs := []string{"image"}
+
+	// Check if SLOW_RUN environment variable is set to "1" and add "--slow" parameter
+	slowRun := redisutil.GetEnv("SLOW_RUN", "0")
+	if slowRun == "1" {
+		cmdArgs = append(cmdArgs, "--slow")
+	}
+
+	cmdArgs = append(cmdArgs, "--format", "json", "--output", resultFileName, "--input", targetDir)
+
+	return cmdArgs
 }


### PR DESCRIPTION
Add an option to run `trivy` in slow mode