### PR TITLE
Move PullWorker main logic to a dedicated package

### DIFF
--- a/pkg/exec_command/exec_command.go
+++ b/pkg/exec_command/exec_command.go
@@ -5,20 +5,24 @@ import (
 )
 
 type IShellCommand interface {
-	SetDir(string)
 	Output() ([]byte, error)
-	Wait() error
+	NewCommand(string, ...string)
 }
 
 type execShellCommand struct {
-	*exec.Cmd
+	cmd *exec.Cmd
 }
 
-func (exc execShellCommand) SetDir(dir string) {
-	exc.Dir = dir
+func (e *execShellCommand) Output() ([]byte, error) {
+	return e.cmd.Output()
+}
+
+func (e *execShellCommand) NewCommand(name string, arg ...string) {
+	e.cmd = exec.Command(name, arg...)
 }
 
 func NewExecShellCommander(name string, arg ...string) IShellCommand {
-	execCmd := exec.Command(name, arg...)
-	return execShellCommand{Cmd: execCmd}
+	shellcmd := &execShellCommand{}
+	shellcmd.NewCommand(name, arg...)
+	return shellcmd
 }

--- a/pkg/exec_command/exec_command_test.go
+++ b/pkg/exec_command/exec_command_test.go
@@ -5,22 +5,10 @@ import (
 )
 
 func TestNewExecShellCommander(t *testing.T) {
-	cmd := NewExecShellCommander("echo", "hello")
-	execCmd := cmd.(execShellCommand)
+	executor := NewExecShellCommander("echo", "hello")
+	execCmd := executor.(*execShellCommand).cmd
 
 	if execCmd.Args[0] != "echo" || len(execCmd.Args) != 2 || execCmd.Args[1] != "hello" {
 		t.Errorf("Command was not constructed correctly")
-	}
-}
-
-func TestSetDir(t *testing.T) {
-	cmd := NewExecShellCommander("pwd")
-	execCmd := cmd.(execShellCommand)
-
-	testDir := "/tmp"
-	execCmd.SetDir(testDir)
-
-	if execCmd.Dir != testDir {
-		t.Errorf("Expected Dir to be %s, got %s", testDir, execCmd.Dir)
 	}
 }

--- a/pkg/pull_worker/pull_worker.go
+++ b/pkg/pull_worker/pull_worker.go
@@ -1,0 +1,59 @@
+package pull_worker
+
+import (
+	"errors"
+	"fmt"
+	"github.com/vpereira/trivy_runner/pkg/exec_command"
+	"os"
+)
+
+var (
+	NoImageGiven = errors.New("PullWorker: No image given")
+)
+
+type PullWorker interface {
+	Pull(target string, dir string) error
+}
+
+type pullWorker struct {
+	execCommand exec_command.IShellCommand
+}
+
+func (p *pullWorker) Pull(imageName string, targetDir string) error {
+	// bail early if no image is given
+	if imageName == "" {
+		return NoImageGiven
+	}
+
+	cmdArgs := GenerateSkopeoCmdArgs(imageName, targetDir)
+	p.execCommand.NewCommand("skopeo", cmdArgs...)
+
+	if _, err := p.execCommand.Output(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewPuller(ec exec_command.IShellCommand) PullWorker {
+	return &pullWorker{ec}
+}
+
+// GenerateSkopeoCmdArgs generates the command line arguments for the skopeo
+// command based on environment variables and input parameters.
+func GenerateSkopeoCmdArgs(imageName, targetDir string) []string {
+	cmdArgs := []string{"copy", "--remove-signatures"}
+
+	// Check and add registry credentials if they are set
+	registryUsername, usernameSet := os.LookupEnv("REGISTRY_USERNAME")
+	registryPassword, passwordSet := os.LookupEnv("REGISTRY_PASSWORD")
+
+	if usernameSet && passwordSet {
+		cmdArgs = append(cmdArgs, "--dest-username", registryUsername, "--dest-password", registryPassword)
+	}
+
+	// Add the rest of the command
+	cmdArgs = append(cmdArgs, fmt.Sprintf("docker://%s", imageName), "oci://"+targetDir)
+
+	return cmdArgs
+}

--- a/pkg/pull_worker/pull_worker_test.go
+++ b/pkg/pull_worker/pull_worker_test.go
@@ -1,0 +1,75 @@
+package pull_worker
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type fakeExecutor struct {
+	Command      []string
+	MockedStdout []byte
+	MockedError  error
+}
+
+func (f *fakeExecutor) Output() ([]byte, error) {
+	return f.MockedStdout, f.MockedError
+}
+
+func (f *fakeExecutor) NewCommand(name string, arg ...string) {
+	f.Command = append([]string{name}, arg...)
+}
+
+func TestPullWorkerHappyPath(t *testing.T) {
+	imageName := "registry.example.com/myimage:latest"
+	targetDir := "/tmp/targetdir"
+	expectedResult := []string{
+		"skopeo",
+		"copy", "--remove-signatures",
+		"docker://registry.example.com/myimage:latest",
+		"oci:///tmp/targetdir",
+	}
+
+	executor := &fakeExecutor{}
+	puller := NewPuller(executor)
+	puller.Pull(imageName, targetDir)
+
+	if !reflect.DeepEqual(executor.Command, expectedResult) {
+		t.Errorf("Puller(%s, %s) executed %v, want %v", imageName, targetDir, executor.Command, expectedResult)
+	}
+}
+
+func TestRaiseError(t *testing.T) {
+	executor := &fakeExecutor{}
+	executor.MockedError = errors.New("signal: killed")
+
+	puller := NewPuller(executor)
+	res := puller.Pull("", "abc")
+
+	if res == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if res != NoImageGiven {
+		t.Fatalf("Expected %v, got %v", NoImageGiven, res)
+	}
+}
+
+func TestNoImage(t *testing.T) {
+	imageName := "registry.example.com/myimage:latest"
+	targetDir := "/tmp/targetdir"
+
+	executor := &fakeExecutor{}
+	executor.MockedError = errors.New("signal: killed")
+
+	puller := NewPuller(executor)
+	res := puller.Pull(imageName, targetDir)
+
+	if res == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if res != executor.MockedError {
+		t.Fatal("Executor failed for the wrong reasons")
+	}
+}


### PR DESCRIPTION
- Dropped unused interface members from exec_command.IShellCommand
- Test the three conditions:
  + no image
  + failed child
  + happy path

- TODO: rewrite constructor not to create commands on start (kept for compat).