### PR TITLE
Add context label in sentry

### DIFF
--- a/cmd/getsizeworker/main.go
+++ b/cmd/getsizeworker/main.go
@@ -22,7 +22,7 @@ var (
 	ctx                       = context.Background()
 	rdb                       *redis.Client
 	airbrakeNotifier          *airbrake.AirbrakeNotifier
-	sentryNotifier            *sentry.SentryNotifier
+	sentryNotifier            sentry.Notifier
 	errorHandler              *error_handler.ErrorHandler
 	imagesAppDir              string
 	logger                    *zap.Logger

--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -22,7 +22,7 @@ var (
 	ctx                       = context.Background()
 	rdb                       *redis.Client
 	airbrakeNotifier          *airbrake.AirbrakeNotifier
-	sentryNotifier            *sentry.SentryNotifier
+	sentryNotifier            sentry.Notifier
 	errorHandler              *error_handler.ErrorHandler
 	imagesAppDir              string
 	logger                    *zap.Logger
@@ -117,7 +117,7 @@ func processQueue() {
 		return
 	}
 
-	// when I add it here it b0rks???
+	sentryNotifier.AddTag("gun", imageName)
 	logger.Info("Processing image: ", zap.String("imageName", imageName))
 	logger.Info("Target directory: ", zap.String("targetDir", targetDir))
 	logger.Info("Target tarball: ", zap.String("targetDir", tarballFilename))
@@ -129,10 +129,6 @@ func processQueue() {
 	cmd := exec_command.NewExecShellCommander("skopeo", cmdArgs...)
 
 	if _, err := cmd.Output(); err != nil {
-		if sentryNotifier != nil {
-			sentryNotifier.AddTag("gun", imageName)
-		}
-
 		errorHandler.Handle(err)
 		return
 	}

--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -117,6 +117,7 @@ func processQueue() {
 		return
 	}
 
+	// when I add it here it b0rks???
 	logger.Info("Processing image: ", zap.String("imageName", imageName))
 	logger.Info("Target directory: ", zap.String("targetDir", targetDir))
 	logger.Info("Target tarball: ", zap.String("targetDir", tarballFilename))
@@ -128,6 +129,10 @@ func processQueue() {
 	cmd := exec_command.NewExecShellCommander("skopeo", cmdArgs...)
 
 	if _, err := cmd.Output(); err != nil {
+		if sentryNotifier != nil {
+			sentryNotifier.AddTag("gun", imageName)
+		}
+
 		errorHandler.Handle(err)
 		return
 	}

--- a/cmd/pullworker/main_test.go
+++ b/cmd/pullworker/main_test.go
@@ -39,7 +39,10 @@ func TestProcessQueue(t *testing.T) {
 	rdb = redis.NewClient(&redis.Options{
 		Addr: mr.Addr(),
 	})
-	_, err = rdb.RPush(ctx, "topull", "registry.suse.com/bci/bci-busybox:latest").Result()
+
+	gun := "registry.suse.com/bci/bci-busybox:latest"
+
+	_, err = rdb.RPush(ctx, "topull", gun).Result()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +78,7 @@ func TestProcessQueue(t *testing.T) {
 		t.Errorf("Sentry tag %s not set", "gun")
 	}
 
-	if value != "registry.suse.com/bci/bci-busybox:latest" {
+	if value != gun {
 		t.Errorf("Sentry tag %s does not match. Want %s got %s", "gun", "registry.suse.com/bci/bci-busybox:latest", value)
 	}
 }

--- a/cmd/pushworker/main.go
+++ b/cmd/pushworker/main.go
@@ -38,7 +38,7 @@ var (
 	rdb               *redis.Client
 	logger            *zap.Logger
 	airbrakeNotifier  *airbrake.AirbrakeNotifier
-	sentryNotifier    *sentry.SentryNotifier
+	sentryNotifier    sentry.Notifier
 	errorHandler      *error_handler.ErrorHandler
 	prometheusMetrics *metrics.Metrics
 )

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -119,6 +119,7 @@ func processQueue() {
 	// Sanitize the image name to create a valid filename
 	resultFileName := calculateResultName(imageName)
 
+	// when I add it here it b0rks???
 	logger.Info("Scanning image:", zap.String("image", imageName))
 	logger.Info("Saving results to:", zap.String("json_report", resultFileName))
 
@@ -128,6 +129,9 @@ func processQueue() {
 	cmd := exec_command.NewExecShellCommander("trivy", cmdArgs...)
 
 	if _, err := cmd.Output(); err != nil {
+		if sentryNotifier != nil {
+			sentryNotifier.AddTag("gun", imageName)
+		}
 		errorHandler.Handle(err)
 		return
 	}

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -114,7 +114,7 @@ func processQueue() {
 	target := parts[1]
 
 	sentryNotifier.AddTag("gun", imageName)
-	sentryNotifier.AddTag("target-dir", targetDir)
+	sentryNotifier.AddTag("target-dir", target)
 	// Delete the image when we're done
 	defer os.RemoveAll(target)
 

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -24,7 +24,7 @@ var (
 	ctx                       = context.Background()
 	rdb                       *redis.Client
 	airbrakeNotifier          *airbrake.AirbrakeNotifier
-	sentryNotifier            *sentry.SentryNotifier
+	sentryNotifier            sentry.Notifier
 	reportsAppDir             string
 	errorHandler              *error_handler.ErrorHandler
 	logger                    *zap.Logger
@@ -113,6 +113,8 @@ func processQueue() {
 	imageName := parts[0]
 	target := parts[1]
 
+	sentryNotifier.AddTag("gun", imageName)
+	sentryNotifier.AddTag("target-dir", targetDir)
 	// Delete the image when we're done
 	defer os.RemoveAll(target)
 

--- a/internal/error_handler/error_handler_test.go
+++ b/internal/error_handler/error_handler_test.go
@@ -19,10 +19,15 @@ func (m *MockAirbrakeNotifier) NotifyAirbrake(err error) {
 
 type MockSentryNotifier struct {
 	NotifyCallCount int
+	Tags            map[string]string
 }
 
 func (m *MockSentryNotifier) NotifySentry(err error) {
 	m.NotifyCallCount++
+}
+
+func (m *MockSentryNotifier) AddTag(key string, value string) {
+	m.Tags[key] = value
 }
 
 func TestErrorHandler_Handle(t *testing.T) {

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -14,7 +14,9 @@ type SentryNotifier struct {
 
 type Notifier interface {
 	NotifySentry(err error)
+	AddTag(name string, value string)
 }
+
 
 // NewSentryNotifier initializes the Sentry client with the DSN from the environment variable.
 func NewSentryNotifier() *SentryNotifier {
@@ -42,4 +44,13 @@ func (s *SentryNotifier) NotifySentry(err error) {
 		sentry.CaptureException(err)
 		sentry.Flush(5 * time.Second)
 	}
+}
+
+func (s *SentryNotifier) AddTag(name string, value string) {
+	if s.Enabled {
+		return;
+	}
+	sentry.ConfigureScope(func(scope *sentry.Scope){
+		scope.SetTag(name, value);
+	})
 }

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -18,7 +18,7 @@ type Notifier interface {
 }
 
 // NewSentryNotifier initializes the Sentry client with the DSN from the environment variable.
-func NewSentryNotifier() *SentryNotifier {
+func NewSentryNotifier() Notifier {
 	dsn := os.Getenv("SENTRY_DSN")
 	if dsn == "" {
 		return &SentryNotifier{Enabled: false}

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -17,7 +17,6 @@ type Notifier interface {
 	AddTag(name string, value string)
 }
 
-
 // NewSentryNotifier initializes the Sentry client with the DSN from the environment variable.
 func NewSentryNotifier() *SentryNotifier {
 	dsn := os.Getenv("SENTRY_DSN")
@@ -25,9 +24,17 @@ func NewSentryNotifier() *SentryNotifier {
 		return &SentryNotifier{Enabled: false}
 	}
 
+	environment := os.Getenv("TRIVY_ENV")
+
+	if environment == "" {
+		environment = "development"
+	}
+
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn: dsn,
+		Dsn:         dsn,
+		Environment: environment,
 	})
+
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 		return &SentryNotifier{Enabled: false}

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -48,9 +48,9 @@ func (s *SentryNotifier) NotifySentry(err error) {
 
 func (s *SentryNotifier) AddTag(name string, value string) {
 	if s.Enabled {
-		return;
+		return
 	}
-	sentry.ConfigureScope(func(scope *sentry.Scope){
-		scope.SetTag(name, value);
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetTag(name, value)
 	})
 }

--- a/internal/sentry/sentry_test.go
+++ b/internal/sentry/sentry_test.go
@@ -10,7 +10,8 @@ func TestNewSentryNotifier(t *testing.T) {
 	t.Run("without DSN", func(t *testing.T) {
 		os.Unsetenv("SENTRY_DSN")
 		notifier := NewSentryNotifier()
-		if notifier.Enabled {
+
+		if notifier.(*SentryNotifier).Enabled {
 			t.Errorf("Expected SentryNotifier to be disabled when DSN is not set")
 		}
 	})
@@ -20,7 +21,7 @@ func TestNewSentryNotifier(t *testing.T) {
 		defer os.Unsetenv("SENTRY_DSN")
 
 		notifier := NewSentryNotifier()
-		if !notifier.Enabled {
+		if !notifier.(*SentryNotifier).Enabled {
 			t.Errorf("Expected SentryNotifier to be enabled when DSN is set")
 		}
 	})


### PR DESCRIPTION
- TODO: understand why it SEGSEV when calling `AddTag` before the logger calls