### PR TITLE
Make the Vectors to store elapsed time for skopeo and trivy wider

### DIFF
--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -30,7 +30,7 @@ var (
 	commandExecutionHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "skopeo_execution_duration_seconds",
 		Help:    "Duration of skopeo execution.",
-		Buckets: prometheus.LinearBuckets(1, 0.5, 20),
+		Buckets: prometheus.LinearBuckets(0, 5, 20),
 	}, []string{"skopeo"})
 )
 

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -32,7 +32,7 @@ var (
 	commandExecutionHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "trivy_execution_duration_seconds",
 		Help:    "Duration of trivy execution.",
-		Buckets: prometheus.LinearBuckets(1, 0.5, 20),
+		Buckets: prometheus.LinearBuckets(0, 5, 20),
 	}, []string{"trivy"})
 )
 


### PR DESCRIPTION
For us important is to have an order of magnitude which jobs are taking longer than others.. so lets use wider buckets (5s instead of 0.5s) 