### PR TITLE
Use exec#CombinedOutput and pass it to the error sent to sentry

### DIFF
--- a/cmd/getsizeworker/main.go
+++ b/cmd/getsizeworker/main.go
@@ -118,7 +118,7 @@ func downloadImageAndGetSize(image, architecture, filePath string) (int64, error
 
 	cmd := exec_command.NewExecShellCommander("skopeo", cmdArgs...)
 
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 
 	if err != nil {
 		return 0, fmt.Errorf("skopeo output: %s, error: %s", string(output), err.Error())
@@ -190,7 +190,6 @@ func processQueue() {
 			logger.Info("Target tarball: ", zap.String("targetDir", tarballFilename))
 			size, err := downloadImageAndGetSize(imageName, architecture, tarballFilename)
 			if err != nil {
-				logger.Error("Error downloading image for architecture", zap.String("image", imageName), zap.String("architecture", architecture))
 				errorHandler.Handle(err)
 				return
 			}
@@ -238,9 +237,9 @@ func GenerateSkopeoInspectCmdArgs(imageName string) []string {
 func getSupportedArchitectures(image string) ([]string, error) {
 	cmdArgs := GenerateSkopeoInspectCmdArgs(image)
 	cmd := exec.Command("skopeo", cmdArgs...)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("skopeo output: %s, error: %s", string(output), err.Error())
 	}
 
 	var manifest struct {

--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -129,8 +129,8 @@ func processQueue() {
 
 	cmd := exec_command.NewExecShellCommander("skopeo", cmdArgs...)
 
-	if _, err := cmd.Output(); err != nil {
-		errorHandler.Handle(err)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		errorHandler.Handle(fmt.Errorf("skopeo output: %s, error: %s", string(output), err.Error()))
 		return
 	}
 

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -132,11 +132,11 @@ func processQueue() {
 	startTime := time.Now()
 	cmd := exec_command.NewExecShellCommander("trivy", cmdArgs...)
 
-	if _, err := cmd.Output(); err != nil {
+	if output, err := cmd.CombinedOutput(); err != nil {
 		if sentryNotifier != nil {
 			sentryNotifier.AddTag("gun", imageName)
 		}
-		errorHandler.Handle(err)
+		errorHandler.Handle(fmt.Errorf("trivy output: %s, error: %s", string(output), err.Error()))
 		return
 	}
 

--- a/pkg/exec_command/exec_command.go
+++ b/pkg/exec_command/exec_command.go
@@ -6,7 +6,7 @@ import (
 
 type IShellCommand interface {
 	SetDir(string)
-	Output() ([]byte, error)
+	CombinedOutput() ([]byte, error)
 	Wait() error
 }
 
@@ -16,6 +16,10 @@ type execShellCommand struct {
 
 func (exc execShellCommand) SetDir(dir string) {
 	exc.Dir = dir
+}
+
+func (exc execShellCommand) CombinedOutput() ([]byte, error) {
+	return exc.Cmd.CombinedOutput()
 }
 
 func NewExecShellCommander(name string, arg ...string) IShellCommand {


### PR DESCRIPTION
Give more information to the Sentry when an error occurs

```
{"level":"error","ts":1717488568.01308,"caller":"error_handler/error_handler.go:30","msg":"An error occurred","error":"skopeo output: time=\"2024-06-04T10:09:28+02:00\" level=fatal msg=\"initializing source docker://registry.suse.com/xoxoxo:latest: reading manifest latest in registry.suse.com/xoxoxo: manifest unknown\"\n, error: exit status 1","stacktrace":"github.com/vpereira/trivy_runner/internal/error_handler.(*ErrorHandler).Handle\n\t/home/vpereira/trivy_runner/internal/error_handler/error_handler.go:30\nmain.processQueue\n\t/home/vpereira/trivy_runner/cmd/pullworker/main.go:133\nmain.main\n\t/home/vpereira/trivy_runner/cmd/pullworker/main.go:93\nruntime.main\n\t/usr/lib64/go/1.21/src/runtime/proc.go:267"}
```

in this PR we are introducing the  "skopeo/trivy output" (stdout/stderr) to the stacktrace