### PR TITLE
Choose architecture if amd64 isnt available

### DIFF
--- a/cmd/getsizeworker/main.go
+++ b/cmd/getsizeworker/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vpereira/trivy_runner/internal/metrics"
 	"github.com/vpereira/trivy_runner/internal/redisutil"
 	"github.com/vpereira/trivy_runner/internal/sentry"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"github.com/vpereira/trivy_runner/pkg/exec_command"
 	"go.uber.org/zap"
 )
@@ -83,7 +84,7 @@ func init() {
 		},
 		commandExecutionHistogram,
 	)
-	imagesAppDir = redisutil.GetEnv("IMAGES_APP_DIR", "/app/images")
+	imagesAppDir = util.GetEnv("IMAGES_APP_DIR", "/app/images")
 }
 
 func main() {

--- a/cmd/getsizeworker/main.go
+++ b/cmd/getsizeworker/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -19,6 +18,7 @@ import (
 	"github.com/vpereira/trivy_runner/internal/metrics"
 	"github.com/vpereira/trivy_runner/internal/redisutil"
 	"github.com/vpereira/trivy_runner/internal/sentry"
+	"github.com/vpereira/trivy_runner/internal/skopeo"
 	"github.com/vpereira/trivy_runner/internal/util"
 	"github.com/vpereira/trivy_runner/pkg/exec_command"
 	"go.uber.org/zap"
@@ -113,7 +113,7 @@ func main() {
 }
 
 func downloadImageAndGetSize(image, architecture, filePath string) (int64, error) {
-	cmdArgs := GenerateSkopeoCmdArgs(image, filePath, architecture)
+	cmdArgs := skopeo.GenerateSkopeoCmdArgs(image, filePath, architecture)
 
 	logger.Info("Executing skopeo with arguments", zap.String("arguments", strings.Join(cmdArgs, " ")))
 
@@ -164,7 +164,7 @@ func processQueue() {
 	logger.Info("Target directory: ", zap.String("targetDir", targetDir))
 
 	// Get the supported architectures for the image
-	architectures, err := getSupportedArchitectures(imageName)
+	architectures, err := skopeo.GetSupportedArchitectures(imageName)
 
 	if err != nil {
 		errorHandler.Handle(err)
@@ -229,44 +229,6 @@ func processQueue() {
 	prometheusMetrics.IncOpsProcessed()
 }
 
-// GenerateSkopeoInspectCmdArgs generates the command line arguments for the skopeo inspect to fetch all supported architectures
-func GenerateSkopeoInspectCmdArgs(imageName string) []string {
-	return []string{"inspect", "--raw", fmt.Sprintf("docker://%s", imageName)}
-}
-
-// getSupportedArchitectures gets the list of supported architectures for a Docker image.
-func getSupportedArchitectures(image string) ([]string, error) {
-	cmdArgs := GenerateSkopeoInspectCmdArgs(image)
-	cmd := exec.Command("skopeo", cmdArgs...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("skopeo output: %s, error: %s", string(output), err.Error())
-	}
-
-	var manifest struct {
-		Manifests []struct {
-			Platform struct {
-				Architecture string `json:"architecture"`
-			} `json:"platform"`
-		} `json:"manifests"`
-	}
-	if err := json.Unmarshal(output, &manifest); err != nil {
-		return nil, err
-	}
-
-	var architectures []string
-	for _, m := range manifest.Manifests {
-		architectures = append(architectures, m.Platform.Architecture)
-	}
-
-	// Ensure at least "amd64" is included if no architectures were found
-	if len(architectures) == 0 {
-		architectures = []string{"amd64"}
-	}
-
-	return architectures, nil
-}
-
 // getFileSize returns the size of the file at the given path in bytes.
 func getFileSize(filePath string) (int64, error) {
 	fileInfo, err := os.Stat(filePath)
@@ -274,28 +236,6 @@ func getFileSize(filePath string) (int64, error) {
 		return 0, err
 	}
 	return fileInfo.Size(), nil
-}
-
-func GenerateSkopeoCmdArgs(imageName, targetFilename, architecture string) []string {
-	cmdArgs := []string{"copy", "--remove-signatures"}
-
-	// Check and add registry credentials if they are set
-	registryUsername, usernameSet := os.LookupEnv("REGISTRY_USERNAME")
-	registryPassword, passwordSet := os.LookupEnv("REGISTRY_PASSWORD")
-
-	if usernameSet && passwordSet {
-		cmdArgs = append(cmdArgs, "--src-username", registryUsername, "--src-password", registryPassword)
-	}
-
-	// Add architecture override if specified
-	if architecture != "" {
-		cmdArgs = append(cmdArgs, "--override-arch", architecture)
-	}
-
-	// Add the rest of the command source image and destination tar
-	cmdArgs = append(cmdArgs, fmt.Sprintf("docker://%s", imageName), fmt.Sprintf("docker-archive://%s", targetFilename))
-
-	return cmdArgs
 }
 
 // sanitizeImageName replaces slashes and colons in the image name with underscores.

--- a/cmd/getsizeworker/main_test.go
+++ b/cmd/getsizeworker/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/vpereira/trivy_runner/internal/metrics"
-	"github.com/vpereira/trivy_runner/internal/redisutil"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -35,7 +35,7 @@ func TestProcessQueue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	imagesAppDir = redisutil.GetEnv("IMAGES_APP_DIR", "/app/images")
+	imagesAppDir = util.GetEnv("IMAGES_APP_DIR", "/app/images")
 
 	prometheusMetrics = metrics.NewMetrics(
 		prometheus.CounterOpts{

--- a/cmd/getsizeworker/main_test.go
+++ b/cmd/getsizeworker/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -57,65 +56,4 @@ func TestProcessQueue(t *testing.T) {
 	defer prometheus.Unregister(commandExecutionHistogram)
 
 	processQueue()
-}
-
-func TestGenerateSkopeoCmdArgs(t *testing.T) {
-	// Define test cases
-	tests := []struct {
-		name           string
-		imageName      string
-		architecture   string
-		targetDir      string
-		envUsername    string
-		envPassword    string
-		expectedResult []string
-	}{
-		{
-			name:         "without credentials",
-			imageName:    "registry.example.com/myimage:latest",
-			targetDir:    "/tmp/targetdir",
-			architecture: "amd64",
-			expectedResult: []string{
-				"copy", "--remove-signatures",
-				"--override-arch", "amd64",
-				"docker://registry.example.com/myimage:latest",
-				"docker-archive:///tmp/targetdir",
-			},
-		},
-		{
-			name:         "with credentials",
-			imageName:    "registry.example.com/myimage:latest",
-			targetDir:    "/tmp/targetdir",
-			envUsername:  "testuser",
-			envPassword:  "testpass",
-			architecture: "amd64",
-			expectedResult: []string{
-				"copy", "--remove-signatures",
-				"--src-username", "testuser", "--src-password", "testpass",
-				"--override-arch", "amd64",
-				"docker://registry.example.com/myimage:latest",
-				"docker-archive:///tmp/targetdir",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Set up environment variables if needed
-			if tc.envUsername != "" && tc.envPassword != "" {
-				os.Setenv("REGISTRY_USERNAME", tc.envUsername)
-				os.Setenv("REGISTRY_PASSWORD", tc.envPassword)
-				defer os.Unsetenv("REGISTRY_USERNAME")
-				defer os.Unsetenv("REGISTRY_PASSWORD")
-			}
-
-			// Call the method under test
-			result := GenerateSkopeoCmdArgs(tc.imageName, tc.targetDir, tc.architecture)
-
-			// Verify the result
-			if !reflect.DeepEqual(result, tc.expectedResult) {
-				t.Errorf("GenerateSkopeoCmdArgs(%s, %s) got %v, want %v", tc.imageName, tc.targetDir, result, tc.expectedResult)
-			}
-		})
-	}
 }

--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vpereira/trivy_runner/internal/metrics"
 	"github.com/vpereira/trivy_runner/internal/redisutil"
 	"github.com/vpereira/trivy_runner/internal/sentry"
+	"github.com/vpereira/trivy_runner/internal/skopeo"
 	"github.com/vpereira/trivy_runner/internal/util"
 	"github.com/vpereira/trivy_runner/pkg/exec_command"
 	"go.uber.org/zap"
@@ -119,12 +120,27 @@ func processQueue() {
 		return
 	}
 
+	toPullArch := "amd64"
+	// TODO
+	// if we want to make trivy multi arch, we need to pull all the archs
+	supportedArchitectures, err := skopeo.GetSupportedArchitectures(imageName)
+
+	if err != nil {
+		errorHandler.Handle(err)
+		return
+	}
+
+	if !util.Contains(supportedArchitectures, "amd64") {
+		toPullArch = supportedArchitectures[0]
+	}
+
 	sentryNotifier.AddTag("image.name", imageName)
 	logger.Info("Processing image: ", zap.String("imageName", imageName))
+	logger.Info("Architecture to pull: ", zap.String("architecture", toPullArch))
 	logger.Info("Target directory: ", zap.String("targetDir", targetDir))
 	logger.Info("Target tarball: ", zap.String("targetDir", tarballFilename))
 
-	cmdArgs := GenerateSkopeoCmdArgs(imageName, tarballFilename)
+	cmdArgs := skopeo.GenerateSkopeoCmdArgs(imageName, tarballFilename, toPullArch)
 
 	startTime := time.Now()
 
@@ -156,22 +172,4 @@ func processQueue() {
 	}
 	prometheusMetrics.CommandExecutionDurationHistogram.WithLabelValues(imageName).Observe(executionTime)
 	prometheusMetrics.IncOpsProcessed()
-}
-
-// GenerateSkopeoCmdArgs generates the command line arguments for the skopeo command based on environment variables and input parameters.
-func GenerateSkopeoCmdArgs(imageName, targetFilename string) []string {
-	cmdArgs := []string{"copy", "--remove-signatures"}
-
-	// Check and add registry credentials if they are set
-	registryUsername, usernameSet := os.LookupEnv("REGISTRY_USERNAME")
-	registryPassword, passwordSet := os.LookupEnv("REGISTRY_PASSWORD")
-
-	if usernameSet && passwordSet {
-		cmdArgs = append(cmdArgs, "--src-username", registryUsername, "--src-password", registryPassword)
-	}
-
-	// Add the rest of the command
-	cmdArgs = append(cmdArgs, fmt.Sprintf("docker://%s", imageName), fmt.Sprintf("docker-archive://%s", targetFilename))
-
-	return cmdArgs
 }

--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vpereira/trivy_runner/internal/metrics"
 	"github.com/vpereira/trivy_runner/internal/redisutil"
 	"github.com/vpereira/trivy_runner/internal/sentry"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"github.com/vpereira/trivy_runner/pkg/exec_command"
 	"go.uber.org/zap"
 )
@@ -66,7 +67,7 @@ func init() {
 		},
 		commandExecutionHistogram,
 	)
-	imagesAppDir = redisutil.GetEnv("IMAGES_APP_DIR", "/app/images")
+	imagesAppDir = util.GetEnv("IMAGES_APP_DIR", "/app/images")
 }
 
 func main() {

--- a/cmd/pullworker/main_test.go
+++ b/cmd/pullworker/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -84,61 +83,5 @@ func TestProcessQueue(t *testing.T) {
 
 	if value != gun {
 		t.Errorf("Sentry tag %s does not match. Want %s got %s", "gun", "registry.suse.com/bci/bci-busybox:latest", value)
-	}
-}
-
-func TestGenerateSkopeoCmdArgs(t *testing.T) {
-	// Define test cases
-	tests := []struct {
-		name           string
-		imageName      string
-		targetDir      string
-		envUsername    string
-		envPassword    string
-		expectedResult []string
-	}{
-		{
-			name:      "without credentials",
-			imageName: "registry.example.com/myimage:latest",
-			targetDir: "/tmp/targetdir",
-			expectedResult: []string{
-				"copy", "--remove-signatures",
-				"docker://registry.example.com/myimage:latest",
-				"docker-archive:///tmp/targetdir",
-			},
-		},
-		{
-			name:        "with credentials",
-			imageName:   "registry.example.com/myimage:latest",
-			targetDir:   "/tmp/targetdir",
-			envUsername: "testuser",
-			envPassword: "testpass",
-			expectedResult: []string{
-				"copy", "--remove-signatures",
-				"--src-username", "testuser", "--src-password", "testpass",
-				"docker://registry.example.com/myimage:latest",
-				"docker-archive:///tmp/targetdir",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Set up environment variables if needed
-			if tc.envUsername != "" && tc.envPassword != "" {
-				os.Setenv("REGISTRY_USERNAME", tc.envUsername)
-				os.Setenv("REGISTRY_PASSWORD", tc.envPassword)
-				defer os.Unsetenv("REGISTRY_USERNAME")
-				defer os.Unsetenv("REGISTRY_PASSWORD")
-			}
-
-			// Call the method under test
-			result := GenerateSkopeoCmdArgs(tc.imageName, tc.targetDir)
-
-			// Verify the result
-			if !reflect.DeepEqual(result, tc.expectedResult) {
-				t.Errorf("GenerateSkopeoCmdArgs(%s, %s) got %v, want %v", tc.imageName, tc.targetDir, result, tc.expectedResult)
-			}
-		})
 	}
 }

--- a/cmd/pullworker/main_test.go
+++ b/cmd/pullworker/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/vpereira/trivy_runner/internal/metrics"
-	"github.com/vpereira/trivy_runner/internal/redisutil"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -49,7 +49,7 @@ func TestProcessQueue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	imagesAppDir = redisutil.GetEnv("IMAGES_APP_DIR", "/app/images")
+	imagesAppDir = util.GetEnv("IMAGES_APP_DIR", "/app/images")
 
 	prometheusMetrics = metrics.NewMetrics(
 		prometheus.CounterOpts{

--- a/cmd/scanworker/main.go
+++ b/cmd/scanworker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vpereira/trivy_runner/internal/metrics"
 	"github.com/vpereira/trivy_runner/internal/redisutil"
 	"github.com/vpereira/trivy_runner/internal/sentry"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"github.com/vpereira/trivy_runner/pkg/exec_command"
 	"go.uber.org/zap"
 )
@@ -68,7 +69,7 @@ func init() {
 		commandExecutionHistogram,
 	)
 
-	reportsAppDir = redisutil.GetEnv("REPORTS_APP_DIR", "/app/reports")
+	reportsAppDir = util.GetEnv("REPORTS_APP_DIR", "/app/reports")
 
 	prometheusMetrics.Register()
 }
@@ -164,7 +165,7 @@ func generateTrivyCmdArgs(resultFileName, target string) []string {
 	cmdArgs := []string{"image"}
 
 	// Check if SLOW_RUN environment variable is set to "1" and add "--slow" parameter
-	slowRun := redisutil.GetEnv("SLOW_RUN", "0")
+	slowRun := util.GetEnv("SLOW_RUN", "0")
 	if slowRun == "1" {
 		cmdArgs = append(cmdArgs, "--slow")
 	}

--- a/internal/redisutil/redis.go
+++ b/internal/redisutil/redis.go
@@ -3,11 +3,10 @@ package redisutil
 import (
 	"context"
 	"log"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/vpereira/trivy_runner/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -19,8 +18,8 @@ func InitializeClient() *redis.Client {
 		log.Fatal("Failed to create logger:", err)
 	}
 
-	redisHost := GetEnv("REDIS_HOST", "localhost")
-	redisPort := GetEnv("REDIS_PORT", "6379")
+	redisHost := util.GetEnv("REDIS_HOST", "localhost")
+	redisPort := util.GetEnv("REDIS_PORT", "6379")
 	redisURL := redisHost + ":" + redisPort
 
 	redisClient := redis.NewClient(&redis.Options{
@@ -30,8 +29,8 @@ func InitializeClient() *redis.Client {
 	})
 
 	// Retry configuration
-	maxRetries := GetEnvAsInt("REDIS_MAX_TRIES", 5)
-	retryInterval := time.Duration(GetEnvAsInt("REDIS_CONNECTION_INTERVAL_RETRY", 2)) * time.Second
+	maxRetries := util.GetEnvAsInt("REDIS_MAX_TRIES", 5)
+	retryInterval := time.Duration(util.GetEnvAsInt("REDIS_CONNECTION_INTERVAL_RETRY", 2)) * time.Second
 
 	for i := 0; i < maxRetries; i++ {
 		_, err := redisClient.Ping(context.Background()).Result()
@@ -48,23 +47,4 @@ func InitializeClient() *redis.Client {
 
 	log.Fatalf("Failed to connect to Redis after %d attempts", maxRetries)
 	return nil
-}
-
-// GetEnv retrieves an environment variable or returns a default value.
-// TODO move this to a common package
-func GetEnv(key, fallback string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	return fallback
-}
-
-// GetEnvAsInt gets an environment variable as an integer, with a fallback default value.
-// TODO move this to a common package
-func GetEnvAsInt(key string, fallback int) int {
-	valueStr := os.Getenv(key)
-	if value, err := strconv.Atoi(valueStr); err == nil {
-		return value
-	}
-	return fallback
 }

--- a/internal/skopeo/main.go
+++ b/internal/skopeo/main.go
@@ -1,0 +1,69 @@
+package skopeo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/vpereira/trivy_runner/pkg/exec_command"
+)
+
+// GenerateSkopeoInspectCmdArgs generates the command line arguments for the skopeo inspect to fetch all supported architectures
+func GenerateSkopeoInspectCmdArgs(imageName string) []string {
+	return []string{"inspect", "--raw", fmt.Sprintf("docker://%s", imageName)}
+}
+
+func GenerateSkopeoCmdArgs(imageName, targetFilename, architecture string) []string {
+	cmdArgs := []string{"copy", "--remove-signatures"}
+
+	// Check and add registry credentials if they are set
+	registryUsername, usernameSet := os.LookupEnv("REGISTRY_USERNAME")
+	registryPassword, passwordSet := os.LookupEnv("REGISTRY_PASSWORD")
+
+	if usernameSet && passwordSet {
+		cmdArgs = append(cmdArgs, "--src-username", registryUsername, "--src-password", registryPassword)
+	}
+
+	// Add architecture override if specified
+	if architecture != "" {
+		cmdArgs = append(cmdArgs, "--override-arch", architecture)
+	}
+
+	// Add the rest of the command source image and destination tar
+	cmdArgs = append(cmdArgs, fmt.Sprintf("docker://%s", imageName), fmt.Sprintf("docker-archive://%s", targetFilename))
+
+	return cmdArgs
+}
+
+// getSupportedArchitectures gets the list of supported architectures for a Docker image.
+func GetSupportedArchitectures(image string) ([]string, error) {
+	cmdArgs := GenerateSkopeoInspectCmdArgs(image)
+	cmd := exec_command.NewExecShellCommander("skopeo", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("skopeo output: %s, error: %s", string(output), err.Error())
+	}
+
+	var manifest struct {
+		Manifests []struct {
+			Platform struct {
+				Architecture string `json:"architecture"`
+			} `json:"platform"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(output, &manifest); err != nil {
+		return nil, err
+	}
+
+	var architectures []string
+	for _, m := range manifest.Manifests {
+		architectures = append(architectures, m.Platform.Architecture)
+	}
+
+	// Ensure at least "amd64" is included if no architectures were found
+	if len(architectures) == 0 {
+		architectures = []string{"amd64"}
+	}
+
+	return architectures, nil
+}

--- a/internal/skopeo/main_test.go
+++ b/internal/skopeo/main_test.go
@@ -1,0 +1,72 @@
+package skopeo
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestGenerateSkopeoInspectCmdArgs(t *testing.T) {
+	imageName := "example/image:latest"
+	expected := []string{"inspect", "--raw", "docker://example/image:latest"}
+
+	result := GenerateSkopeoInspectCmdArgs(imageName)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GenerateSkopeoInspectCmdArgs(%s) = %v; expected %v", imageName, result, expected)
+	}
+}
+
+func TestGenerateSkopeoCmdArgs(t *testing.T) {
+	tests := []struct {
+		imageName      string
+		targetFilename string
+		architecture   string
+		envUsername    string
+		envPassword    string
+		expected       []string
+	}{
+		{
+			"example/image:latest",
+			"image.tar",
+			"amd64",
+			"",
+			"",
+			[]string{"copy", "--remove-signatures", "--override-arch", "amd64", "docker://example/image:latest", "docker-archive://image.tar"},
+		},
+		{
+			"example/image:latest",
+			"image.tar",
+			"",
+			"",
+			"",
+			[]string{"copy", "--remove-signatures", "docker://example/image:latest", "docker-archive://image.tar"},
+		},
+		{
+			"example/image:latest",
+			"image.tar",
+			"arm64",
+			"user",
+			"pass",
+			[]string{"copy", "--remove-signatures", "--src-username", "user", "--src-password", "pass", "--override-arch", "arm64", "docker://example/image:latest", "docker-archive://image.tar"},
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.envUsername != "" {
+			os.Setenv("REGISTRY_USERNAME", tt.envUsername)
+		} else {
+			os.Unsetenv("REGISTRY_USERNAME")
+		}
+
+		if tt.envPassword != "" {
+			os.Setenv("REGISTRY_PASSWORD", tt.envPassword)
+		} else {
+			os.Unsetenv("REGISTRY_PASSWORD")
+		}
+
+		result := GenerateSkopeoCmdArgs(tt.imageName, tt.targetFilename, tt.architecture)
+		if !reflect.DeepEqual(result, tt.expected) {
+			t.Errorf("GenerateSkopeoCmdArgs(%s, %s, %s) = %v; expected %v", tt.imageName, tt.targetFilename, tt.architecture, result, tt.expected)
+		}
+	}
+}

--- a/internal/util/main.go
+++ b/internal/util/main.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"os"
+	"strconv"
+)
+
+// GetEnv retrieves an environment variable or returns a default value.
+// TODO move this to a common package
+func GetEnv(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
+
+// GetEnvAsInt gets an environment variable as an integer, with a fallback default value.
+// TODO move this to a common package
+func GetEnvAsInt(key string, fallback int) int {
+	valueStr := os.Getenv(key)
+	if value, err := strconv.Atoi(valueStr); err == nil {
+		return value
+	}
+	return fallback
+}

--- a/internal/util/main.go
+++ b/internal/util/main.go
@@ -23,3 +23,13 @@ func GetEnvAsInt(key string, fallback int) int {
 	}
 	return fallback
 }
+
+// contains checks if a string is in a slice.
+func Contains(slice []string, item string) bool {
+	for _, a := range slice {
+		if a == item {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/main_test.go
+++ b/internal/util/main_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetEnv(t *testing.T) {
+	tests := []struct {
+		key      string
+		value    string
+		fallback string
+		expected string
+	}{
+		{"EXISTING_KEY", "value1", "default1", "value1"},
+		{"NON_EXISTING_KEY", "", "default2", "default2"},
+	}
+
+	for _, tt := range tests {
+		if tt.value != "" {
+			os.Setenv(tt.key, tt.value)
+		} else {
+			os.Unsetenv(tt.key)
+		}
+
+		result := GetEnv(tt.key, tt.fallback)
+		if result != tt.expected {
+			t.Errorf("GetEnv(%s, %s) = %s; expected %s", tt.key, tt.fallback, result, tt.expected)
+		}
+	}
+}
+
+func TestGetEnvAsInt(t *testing.T) {
+	tests := []struct {
+		key      string
+		value    string
+		fallback int
+		expected int
+	}{
+		{"EXISTING_INT_KEY", "123", 456, 123},
+		{"INVALID_INT_KEY", "abc", 456, 456},
+		{"NON_EXISTING_INT_KEY", "", 456, 456},
+	}
+
+	for _, tt := range tests {
+		if tt.value != "" {
+			os.Setenv(tt.key, tt.value)
+		} else {
+			os.Unsetenv(tt.key)
+		}
+
+		result := GetEnvAsInt(tt.key, tt.fallback)
+		if result != tt.expected {
+			t.Errorf("GetEnvAsInt(%s, %d) = %d; expected %d", tt.key, tt.fallback, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
In this PR we are improving the following areas:

- We had in pullworker and in the getsizeworker the code to generate skopeo commands. Now they are consuming the same method
- Move method from `redisutil` to `util` package
- In case an image doesn't support amd64 and it has multiarch support, choose the first architecture to download the tar ball and be able to run trivy on that. 

image without amd64.

```
vpereira@linux-qouy:~/trivy_runner> IMAGES_APP_DIR=/tmp bin/pull_worker 
2024/06/04 15:18:34 Successfully connected to Redis at localhost:6379
2024/06/04 15:18:34 Metrics server started on :8082
{"level":"info","ts":1717507140.6810102,"caller":"pullworker/main.go:136","msg":"Processing image: ","imageName":"registry.suse.com/suse/sles12sp4:26.246"}
{"level":"info","ts":1717507140.6811368,"caller":"pullworker/main.go:137","msg":"Architecture to pull: ","architecture":"ppc64le"}
{"level":"info","ts":1717507140.681164,"caller":"pullworker/main.go:138","msg":"Target directory: ","targetDir":"/tmp/trivy-scan-4165415715"}
{"level":"info","ts":1717507140.6811805,"caller":"pullworker/main.go:139","msg":"Target tarball: ","targetDir":"/tmp/trivy-scan-4165415715/image.tar"}
{"level":"info","ts":1717507145.01328,"caller":"pullworker/main.go:163","msg":"Pushing image to toscan queue:","image":"registry.suse.com/suse/sles12sp4:26.246|/tmp/trivy-scan-4165415715/image.tar"}
```
