### PR TITLE
Jsonify the data from scan/getsize worker -> pushworker

### DIFF
--- a/internal/pushworker/types.go
+++ b/internal/pushworker/types.go
@@ -7,7 +7,7 @@ import (
 // DTO's to be used internally through the redis queue
 
 type GetSizeResult struct {
-	Sizes map[string]int64 `json:"sizes"`
+	Sizes map[string]int64 `json:"uncompressed_sizes"`
 }
 
 type ScanResult struct {

--- a/internal/pushworker/types.go
+++ b/internal/pushworker/types.go
@@ -1,0 +1,61 @@
+package pushworker
+
+import (
+	"encoding/json"
+)
+
+// DTO's to be used internally through the redis queue
+
+type GetSizeResult struct {
+	Sizes map[string]int64 `json:"sizes"`
+}
+
+type ScanResult struct {
+	ResultFilePath string
+}
+
+type DTO struct {
+	GetSizeResult
+	ScanResult
+	Operation string
+	Image     string
+}
+
+func (dto *DTO) ToJSON() ([]byte, error) {
+	return json.Marshal(dto)
+}
+
+func NewScanDTO() DTO {
+	return DTO{
+		Operation: "scan",
+	}
+}
+
+func NewGetSizeDTO() DTO {
+	return DTO{
+		Operation:     "get-uncompressed-size",
+		GetSizeResult: GetSizeResult{Sizes: make(map[string]int64)},
+	}
+}
+
+// Final structs to be used for pushing results out of trivy
+
+type GetSizePayload = GetSizeResult
+
+type ScanPayload struct {
+	RanAt   string          `json:"ran_at"`
+	Results json.RawMessage `json:"results"`
+}
+
+type Payload struct {
+	ScanPayload
+	GetSizePayload
+	Image     string `json:"image"`
+	Operation string `json:"operation"`
+}
+
+func NewPayload() Payload {
+	return Payload{
+		GetSizePayload: GetSizePayload{Sizes: make(map[string]int64)},
+	}
+}


### PR DESCRIPTION
- Scan/Size workers send JSON messages to pushworker with all data needed. The payload now includes the current operation.

- Pushworker translates the data as before (scan result filename is converted to the actual JSON content before sending).

- Tested the outputs to the Webhook.