### PR TITLE
Add initial SkopeoWorker multiarch support

### DIFF
--- a/cmd/pullworker/main.go
+++ b/cmd/pullworker/main.go
@@ -15,6 +15,7 @@ func main() {
 		ErrorsTotalName: "pullworker_processed_errors_total",
 		ErrorsTotalHelp: "Total number of processed errors by the pullworker.",
 		ServerPort:      util.GetEnv("PROMETHEUS_EXPORTER_PORT", "8082"),
+		MultiArch:       false,
 	}
 
 	pullWorker, err := skopeo_worker.InitializeWorker(config)

--- a/internal/skopeo_worker/config.go
+++ b/internal/skopeo_worker/config.go
@@ -7,4 +7,5 @@ type Config struct {
 	ErrorsTotalName string
 	ErrorsTotalHelp string
 	ServerPort      string
+	MultiArch       bool
 }

--- a/internal/skopeo_worker/init.go
+++ b/internal/skopeo_worker/init.go
@@ -82,6 +82,7 @@ func InitializeWorker(config Config) (*SkopeoWorker, error) {
 		CommandExecutionHistogram: commandExecutionHistogram,
 		PrometheusMetrics:         prometheusMetrics,
 		ProcessQueueName:          config.QueueName,
+		MultiArch:                 config.MultiArch,
 		CommandFactory:            exec_command.NewExecShellCommander,
 		ProcessFunc:               ProcessQueue,
 	}, nil

--- a/internal/skopeo_worker/main.go
+++ b/internal/skopeo_worker/main.go
@@ -27,11 +27,12 @@ type SkopeoWorker struct {
 	CommandExecutionHistogram *prometheus.HistogramVec
 	PrometheusMetrics         *metrics.Metrics
 	ProcessQueueName          string
+	MultiArch                 bool
 	ProcessFunc               func(commandFactory func(name string, arg ...string) exec_command.IShellCommand, worker *SkopeoWorker)
 	CommandFactory            func(name string, arg ...string) exec_command.IShellCommand
 }
 
-func NewSkopeoWorker(ctx context.Context, rdb *redis.Client, sentryNotifier sentry.Notifier, errorHandler *error_handler.ErrorHandler, logger *zap.Logger, imagesAppDir string, histogram *prometheus.HistogramVec, processQueueName string, processFunc func(commandFactory func(name string, arg ...string) exec_command.IShellCommand, worker *SkopeoWorker), commandFactory func(name string, arg ...string) exec_command.IShellCommand) *SkopeoWorker {
+func NewSkopeoWorker(ctx context.Context, rdb *redis.Client, sentryNotifier sentry.Notifier, errorHandler *error_handler.ErrorHandler, logger *zap.Logger, imagesAppDir string, histogram *prometheus.HistogramVec, processQueueName string, multiArch bool, processFunc func(commandFactory func(name string, arg ...string) exec_command.IShellCommand, worker *SkopeoWorker), commandFactory func(name string, arg ...string) exec_command.IShellCommand) *SkopeoWorker {
 	return &SkopeoWorker{
 		Ctx:                       ctx,
 		Rdb:                       rdb,
@@ -41,6 +42,7 @@ func NewSkopeoWorker(ctx context.Context, rdb *redis.Client, sentryNotifier sent
 		ImagesAppDir:              imagesAppDir,
 		CommandExecutionHistogram: histogram,
 		ProcessQueueName:          processQueueName,
+		MultiArch:                 multiArch,
 		ProcessFunc:               processFunc,
 		CommandFactory:            commandFactory,
 	}


### PR DESCRIPTION
To be able to reuse code between `cmd/pull_worker` and `cmd/getsizes_worker` add a flag to control if we want to run skopeo multiarch