### PR TITLE
Log the right image name in the pushworker

### DIFF
--- a/cmd/pushworker/main.go
+++ b/cmd/pushworker/main.go
@@ -135,7 +135,6 @@ func extractResults(filePath string) (json.RawMessage, error) {
 
 func sendToWebhook(webhookURL string, result interface{}) {
 	jsonData, err := json.Marshal(result)
-	imageName := reflect.TypeOf(result).Name()
 
 	if err != nil {
 		errorHandler.Handle(err)
@@ -166,6 +165,7 @@ func sendToWebhook(webhookURL string, result interface{}) {
 		errorHandler.Handle(err)
 		return
 	}
-	logger.Info("Report sent successfully for image:", zap.String("image", imageName))
+	imageName := reflect.ValueOf(result).FieldByName("Image").String()
+	logger.Info("Report sent successfully for: ", zap.String("image", imageName))
 	prometheusMetrics.IncOpsProcessed()
 }


### PR DESCRIPTION
before this PR:

```
{"level":"info","ts":1718870633.9885015,"caller":"pushworker/main.go:169","msg":"Report sent successfully for image:","image":"Paylo │
│ ad"}
```

after this PR:

```
2024/06/20 10:01:54 Metrics server started on :8083
{"level":"info","ts":1718870514.875342,"caller":"pushworker/main.go:170","msg":"Report sent successfully for image:","image":"registry.suse.com/bci/bci-busybox:latest"}

```