### PR TITLE
Make sure we drop items from processing queue when Processing is done

### DIFF
--- a/internal/skopeo_worker/main.go
+++ b/internal/skopeo_worker/main.go
@@ -84,6 +84,8 @@ func ProcessQueueMultiArch(commandFactory func(name string, arg ...string) exec_
 		return
 	}
 
+	defer worker.Rdb.LRem(worker.Ctx, worker.getProcessingQueueName(hostName), 1, messageJSON).Result()
+
 	imageNameSanitized := util.SanitizeImageName(imageName)
 
 	targetDir, err := os.MkdirTemp(worker.ImagesAppDir, "trivy-scan-*")
@@ -165,6 +167,8 @@ func ProcessQueue(commandFactory func(name string, arg ...string) exec_command.I
 		worker.ErrorHandler.Handle(err)
 		return
 	}
+
+	defer worker.Rdb.LRem(worker.Ctx, worker.getProcessingQueueName(hostName), 1, messageJSON).Result()
 
 	targetDir, err := os.MkdirTemp(worker.ImagesAppDir, "trivy-scan-*")
 


### PR DESCRIPTION
In some scenarios that we submit non-existing images/tags to the trivy scanner, it gets removed if skopeo aborts