### PR TITLE
Add a redis exporter with the queue sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-.PHONY: all webapi pullworker scanworker pushworker sbomworker getsizeworker test format lint
+.PHONY: all webapi pullworker scanworker pushworker sbomworker getsizeworker test format lint  redisexporter
 
-all: webapi pullworker scanworker pushworker getsizeworker sbomworker
+all: webapi pullworker scanworker pushworker getsizeworker sbomworker redisexporter
 
 test:
 	go test ./...
 
 format:
 	go fmt ./...
+
+redisexporter:
+	go build -o ./bin/redis_exporter ./cmd/redisexporter
+
 webapi:
 	go build -o ./bin/webapi ./cmd/webapi
 
@@ -31,5 +35,3 @@ integration-server:
 
 lint:
 	docker run --rm -v "$(CURDIR):/app" -w /app golangci/golangci-lint:v1.55.2 golangci-lint run -v
-
-

--- a/cmd/redisexporter/main.go
+++ b/cmd/redisexporter/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/redis/go-redis/v9"
+	"github.com/vpereira/trivy_runner/internal/metrics"
+	"github.com/vpereira/trivy_runner/internal/redisutil"
+	"go.uber.org/zap"
+)
+
+type Config struct {
+	rdb      *redis.Client
+	Hostname string
+	Queues   map[string]string
+}
+
+var (
+	logger, _        = zap.NewProduction()
+	redisQueueLength *prometheus.GaugeVec
+	once             sync.Once
+)
+
+func initMetrics() {
+	once.Do(func() {
+		redisQueueLength = promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "redis_queue_length",
+				Help: "Length of Redis queues",
+			},
+			[]string{"host", "queue_name"},
+		)
+	})
+}
+
+func getQueuesFromEnv() map[string]string {
+	queuesEnv := os.Getenv("REDIS_QUEUES")
+	queues := make(map[string]string)
+
+	if queuesEnv != "" {
+		queueList := strings.Fields(queuesEnv) // Split the string by whitespace
+		for _, queueName := range queueList {
+			queues[queueName] = "" // Set each queue name with an empty string as the value
+		}
+	}
+
+	return queues
+}
+
+func updateQueueMetrics(ctx context.Context, config Config) {
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("Shutting down updateQueueMetrics goroutine")
+			return
+		default:
+			for queueName := range config.Queues {
+				length, err := config.rdb.LLen(ctx, queueName).Result()
+				if err != nil {
+					logger.Error("Error getting length of queue", zap.String("queue", queueName), zap.Error(err))
+					continue
+				}
+				redisQueueLength.WithLabelValues(config.Hostname, queueName).Set(float64(length))
+			}
+			time.Sleep(10 * time.Second) // Update every 10 seconds
+		}
+	}
+}
+
+func main() {
+	defer logger.Sync()
+
+	rdb := redisutil.InitializeClient()
+	queues := getQueuesFromEnv()
+	hostName, _ := os.Hostname()
+
+	initMetrics()
+
+	config := Config{
+		rdb:      rdb,
+		Queues:   queues,
+		Hostname: hostName,
+	}
+
+	// Metrics are already registered inside initMetrics() with promauto
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the metrics update in a separate goroutine
+	go updateQueueMetrics(ctx, config)
+	go metrics.StartMetricsServer("8086")
+
+	// Graceful shutdown on interrupt signal
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, syscall.SIGINT, syscall.SIGTERM)
+
+	<-stopChan
+	logger.Info("Received shutdown signal, shutting down gracefully...")
+	cancel()                    // Signal all goroutines to finish
+	time.Sleep(1 * time.Second) // Give goroutines time to shutdown
+}

--- a/cmd/redisexporter/main.go
+++ b/cmd/redisexporter/main.go
@@ -41,14 +41,16 @@ func initMetrics() {
 	})
 }
 
+// We parse the REDIS_QUEUES environment variable to get the list of queues
+// i.e REDIS_QUEUES="queueA queueB queueC"
 func getQueuesFromEnv() map[string]string {
 	queuesEnv := os.Getenv("REDIS_QUEUES")
 	queues := make(map[string]string)
 
 	if queuesEnv != "" {
-		queueList := strings.Fields(queuesEnv) // Split the string by whitespace
+		queueList := strings.Fields(queuesEnv)
 		for _, queueName := range queueList {
-			queues[queueName] = "" // Set each queue name with an empty string as the value
+			queues[queueName] = ""
 		}
 	}
 
@@ -70,7 +72,7 @@ func updateQueueMetrics(ctx context.Context, config Config) {
 				}
 				redisQueueLength.WithLabelValues(config.Hostname, queueName).Set(float64(length))
 			}
-			time.Sleep(10 * time.Second) // Update every 10 seconds
+			time.Sleep(10 * time.Second)
 		}
 	}
 }
@@ -90,12 +92,9 @@ func main() {
 		Hostname: hostName,
 	}
 
-	// Metrics are already registered inside initMetrics() with promauto
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the metrics update in a separate goroutine
 	go updateQueueMetrics(ctx, config)
 	go metrics.StartMetricsServer("8086")
 

--- a/cmd/redisexporter/main_test.go
+++ b/cmd/redisexporter/main_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/redis/go-redis/v9"
+)
+
+func init() {
+	// Reset the global Prometheus registry before each test
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+}
+
+func TestGetQueuesFromEnv(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected map[string]string
+	}{
+		{
+			envValue: "queueA queueB queueC",
+			expected: map[string]string{
+				"queueA": "",
+				"queueB": "",
+				"queueC": "",
+			},
+		},
+		{
+			envValue: "queue1 queue2",
+			expected: map[string]string{
+				"queue1": "",
+				"queue2": "",
+			},
+		},
+		{
+			envValue: "",
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		// Set environment variable
+		t.Setenv("REDIS_QUEUES", tt.envValue)
+
+		// Get queues from environment
+		result := getQueuesFromEnv()
+
+		// Compare result with expected value
+		if len(result) != len(tt.expected) {
+			t.Fatalf("expected %v queues, got %v", len(tt.expected), len(result))
+		}
+
+		for queue := range tt.expected {
+			if _, ok := result[queue]; !ok {
+				t.Errorf("expected queue %v to be in the result", queue)
+			}
+		}
+	}
+}
+
+func TestUpdateQueueMetrics(t *testing.T) {
+	// Start a miniredis server
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("Failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	// Populate miniredis with some data
+	mr.Lpush("queueA", "item1")
+	mr.Lpush("queueA", "item1")
+	mr.Lpush("queueA", "item1")
+	mr.Lpush("queueB", "item1")
+	mr.Lpush("queueB", "item1")
+
+	// Create a real Redis client connected to miniredis
+	rdb := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+
+	initMetrics() // Initialize the metrics
+
+	config := Config{
+		rdb:      rdb,
+		Hostname: "localhost",
+		Queues:   map[string]string{"queueA": "", "queueB": ""},
+	}
+
+	// Create a context to control the lifecycle of the goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run the metrics update in a goroutine
+	go updateQueueMetrics(ctx, config)
+
+	// Allow some time for the metrics to be updated
+	time.Sleep(1 * time.Second)
+
+	// Validate the metrics
+	metric := testutil.ToFloat64(redisQueueLength.WithLabelValues("localhost", "queueA"))
+	if metric != 3 {
+		t.Errorf("Expected metric value 3 for queueA, got %v", metric)
+	}
+
+	metric = testutil.ToFloat64(redisQueueLength.WithLabelValues("localhost", "queueB"))
+	if metric != 2 {
+		t.Errorf("Expected metric value 2 for queueB, got %v", metric)
+	}
+}


### PR DESCRIPTION
Having some data in the queue, we can get this metric via the endpoint /metrics

```
vpereira@linux-qouy:~/terraform/terraform-proxmox/ubuntu/ansible> curl http://localhost:8086/metrics | grep redis_queue_length
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8790    0  8790    0     0  2346k      0 --:--:-- --:--:-- --:--:-- 2861k
# HELP redis_queue_length Length of Redis queues
# TYPE redis_queue_length gauge
redis_queue_length{host="linux-qouy",queue_name="getsize"} 9
redis_queue_length{host="linux-qouy",queue_name="topull"} 10
```